### PR TITLE
Refactor CublasScopedContextHandler

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -17,11 +17,6 @@
 *
 **************************************************************************/
 #include "cublas_scope_handle.hpp"
-#if __has_include(<sycl/detail/common.hpp>)
-#include <sycl/detail/common.hpp>
-#else
-#include <CL/sycl/detail/common.hpp>
-#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -73,7 +73,6 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 
 class CublasScopedContextHandler {
     CUcontext original_;
-    sycl::context* placedContext_;
     sycl::interop_handle& ih;
     static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);
@@ -82,7 +81,6 @@ class CublasScopedContextHandler {
 public:
     CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih);
 
-    ~CublasScopedContextHandler() noexcept(false);
     /**
    * @brief get_handle: creates the handle by implicitly impose the advice
    * given by nvidia for creating a cublas_handle. (e.g. one cuStream per device

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -23,15 +23,6 @@
 #else
 #include <CL/sycl.hpp>
 #endif
-#if __has_include(<sycl/context.hpp>)
-#if __SYCL_COMPILER_VERSION <= 20220930
-#include <sycl/backend/cuda.hpp>
-#endif
-#include <sycl/context.hpp>
-#else
-#include <CL/sycl/backend/cuda.hpp>
-#include <CL/sycl/context.hpp>
-#endif
 
 #include <atomic>
 #include <memory>

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -33,18 +33,6 @@
 #include <CL/sycl/context.hpp>
 #endif
 
-// After Plugin Interface removal in DPC++ ur.hpp is the new include
-#if __has_include(<sycl/detail/ur.hpp>)
-#include <sycl/detail/ur.hpp>
-#ifndef ONEMKL_PI_INTERFACE_REMOVED
-#define ONEMKL_PI_INTERFACE_REMOVED
-#endif
-#elif __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
-#else
-#include <CL/sycl/detail/pi.hpp>
-#endif
-
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -88,11 +76,7 @@ class CublasScopedContextHandler {
     sycl::context* placedContext_;
     bool needToRecover_;
     sycl::interop_handle& ih;
-#ifdef ONEMKL_PI_INTERFACE_REMOVED
-    static thread_local cublas_handle<ur_context_handle_t> handle_helper;
-#else
-    static thread_local cublas_handle<pi_context> handle_helper;
-#endif
+    static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);
     sycl::context get_context(const sycl::queue& queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -74,7 +74,6 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 class CublasScopedContextHandler {
     CUcontext original_;
     sycl::context* placedContext_;
-    bool needToRecover_;
     sycl::interop_handle& ih;
     static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -35,18 +35,6 @@
 #else
 #include "cublas_scope_handle_hipsycl.hpp"
 
-// After Plugin Interface removal in DPC++ ur.hpp is the new include
-#if __has_include(<sycl/detail/ur.hpp>)
-#include <sycl/detail/ur.hpp>
-#ifndef ONEMKL_PI_INTERFACE_REMOVED
-#define ONEMKL_PI_INTERFACE_REMOVED
-#endif
-#elif __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
-#else
-#include <CL/sycl/detail/pi.hpp>
-#endif
-
 namespace sycl {
 using interop_handler = sycl::interop_handle;
 }


### PR DESCRIPTION
There were a few different problems with the current way of things. **It's the best to look chronologically what each commit does.** I tried to follow the approach of "solve one problem and that will hopefully make it easier to fix later ones" which I think worked. 

The fixes: 

1. We don't need to include the UR header. We can replace the type of the `cublas_handle` map to be `CUcontext` instead of `ur_context_handle_t` ~ commit 1
2. Nowadays, we only use the primary context in sycl. So if we have only one device, the map will have only one entry: CuDevicePrimaryCtx -> CublasHandle. We also don't need to check if the current cuda context is primary or not. It's always primary. ~ commit 2
3. We were using `ContextSetExtendedDeleter` in the past I think for performance reasons. In the past, when we were also using other cuda contexts in sycl, the `cublas_handle` map would have more entries with more handles. We wanted for some of those entries to be deleted when the instance of `CublasScopedContextHandler` goes out of scope. This is not required anymore due to the use of primary context. ~ commit 3, 4
4. In our map, we don't need to have the `CublasHandle_t` to be wrapped into `std::atomic` and created on a heap with `new`. We actually can just have the map of `CUdevice -> CublasHandle_t` ~ commit 5, 6
5. To do the previous point we would need to modify the `cublas_handle` struct which we share with HIPSYCL. We could avoid that by dropping the use of it at all and use `static thread_local shared_ptr<unordered_map>` with custom deleter which destroys the cublas handles when the thread is destroyed ~ commit 7